### PR TITLE
Preserve advertisements for retrieved peripherals

### DIFF
--- a/BlueCapKit/Central/CentralManager.swift
+++ b/BlueCapKit/Central/CentralManager.swift
@@ -323,6 +323,7 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
             bcPeripheral = discoveredPeripheral
             if bcPeripheral.cbPeripheral === peripheral {
                 bcPeripheral._RSSI = RSSI.intValue
+                bcPeripheral.updateAdvertisements(advertisementData)
                 afterPeripheralDiscoveredPromise?.success(bcPeripheral)
             } else {
                 afterPeripheralDiscoveredPromise?.failure(CentralManagerError.invalidPeripheral)

--- a/BlueCapKit/Central/Peripheral.swift
+++ b/BlueCapKit/Central/Peripheral.swift
@@ -209,6 +209,12 @@ public class Peripheral: NSObject, CBPeripheralDelegate {
         }
     }
 
+    // MARK: Advertisements
+
+    public func updateAdvertisements(_ advertisementData: [String: Any]) {
+        self.advertisements = PeripheralAdvertisements(advertisements: advertisementData)
+    }
+
     // MARK: RSSI
 
     public func readRSSI() -> Future<Int> {


### PR DESCRIPTION
Fixes a bug where advertisement data would be dropped for peripherals that were retrieved from the system.